### PR TITLE
Allow imposm of import_osm.sh to be configured

### DIFF
--- a/import_osm.sh
+++ b/import_osm.sh
@@ -34,7 +34,8 @@ function import_pbf() {
         -cachedir "$IMPOSM_CACHE_DIR" \
         -read "$pbf_file" \
         -deployproduction \
-        -write $diff_flag
+        -write $diff_flag \
+        -config "$CONFIG_JSON"
 }
 
 function import_osm_with_first_pbf() {


### PR DESCRIPTION
Configuring imposm also on import allows to produce a right last.state.txt directly at import.